### PR TITLE
PP-4061 Added delayed capture, capture endpoint interactions

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,3 +76,15 @@ $ curl -d '{"amount": 100,"reference": "12345","description":"New passport appli
 ### Refund information - where no refund is found
 
 $ curl -d '{"amount": 100,"reference": "12345","description":"New passport application","card_details":{"first_digits_card_number":"111","last_digits_card_number":"222","name_on_card":"Mr Card","card_brand":"card-brand","from_date":"2016-01-21T17:15:00Z","to_date":"2016-01-23T17:15:00Z"},"page":"example-page","display_size":"example-display-size","email":"","language":"en","payment_url":{"href":"https://publicapi.example.com/v1/payments/abc123"}}' -H 'Authorization: BEARER_TOKEN' -H 'Content-Type: application/json' http://localhost:8000/v1/refunds-2 
+
+### Initiate capture for a previously delayed capture payment
+
+$ curl -X POST -H 'Authorization: BEARER_TOKEN' -H 'Content-Type: application/json' http://localhost:8000/v1/payments-9/hu20sqlact5260q2nanm0q8u93/capture
+
+### Initiate capture for a payment not set to delayed capture
+
+$ curl -X POST -H 'Authorization: BEARER_TOKEN' -H 'Content-Type: application/json' http://localhost:8000/v1/payments-10/123notadelayedcapturepayment789/capture
+
+### Initiate capture for a non existing payment
+
+$ curl -X POST -H 'Authorization: BEARER_TOKEN' -H 'Content-Type: application/json' http://localhost:8000/v1/payments-11/789nonexistingpayment123/capture

--- a/pacts/apiclient-to-be-publicapi.json
+++ b/pacts/apiclient-to-be-publicapi.json
@@ -1192,6 +1192,93 @@
           "match": "type"
         }
       }
+    },
+    {
+      "description": "a capture is initiated, after previously being delayed",
+      "request": {
+        "method": "POST",
+        "path": "/v1/payments-9/hu20sqlact5260q2nanm0q8u93/capture",
+        "headers": {
+          "Authorization": "Bearer BEARER_TOKEN",
+          "Content-Type": "application/json"
+        },
+        "matchingRules": {}
+      },
+      "response": {
+        "status": 204,
+        "headers": {
+          "Content-Type": "application/json"
+        }
+      },
+      "matchingRules": {}
+    },
+    {
+      "description": "a capture is initiated, for a payment that has not been created as a delayed capture payment",
+      "request": {
+        "method": "POST",
+        "path": "/v1/payments-10/123notadelayedcapturepayment789/capture",
+        "headers": {
+          "Authorization": "Bearer BEARER_TOKEN",
+          "Content-Type": "application/json"
+        },
+        "matchingRules": {}
+      },
+      "response": {
+        "status": 409,
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "body": {
+          "field": "paymentId",
+          "code": "P1003",
+          "description": "Invalid attribute value: paymentId. Must be in awaiting_capture state"
+        }
+      },
+      "matchingRules": {
+        "$.body.field": {
+          "match": "type"
+        },
+        "$.body.code": {
+          "match": "type"
+        },
+        "$.body.description": {
+          "match": "type"
+        }
+      }
+    },
+    {
+      "description": "a capture is initiated, for a payment that does not exist",
+      "request": {
+        "method": "POST",
+        "path": "/v1/payments-11/789nonexistingpayment123/capture",
+        "headers": {
+          "Authorization": "Bearer BEARER_TOKEN",
+          "Content-Type": "application/json"
+        },
+        "matchingRules": {}
+      },
+      "response": {
+        "status": 404,
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "body": {
+          "field": "paymentId",
+          "code": "P1000",
+          "description": "Invalid attribute value: paymentId. paymentId does not exist"
+        }
+      },
+      "matchingRules": {
+        "$.body.field": {
+          "match": "type"
+        },
+        "$.body.code": {
+          "match": "type"
+        },
+        "$.body.description": {
+          "match": "type"
+        }
+      }
     }
   ],
   "metadata": {


### PR DESCRIPTION
Adds interactions to support three scenarios when calling our payments endpoint to initiate a capture that was previously flagged for 'delayed capture' when the payment was created.

- a valid request to start capture for payment flagged as delayed
- an invalid request to start capture for a payment not flagged as delayed
- an invalid request to start capture for a non existent payment