### PR TITLE
update from address to billing_address

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ $ curl -H 'Authorization: BEARER_TOKEN' -H 'Content-Type: application/json' http
 
 ### Create a payment when english language has been specified, as well as an email and postal address supplied
 
-$ curl -d '{"amount": 50000,"reference": "12345","description": "New passport application","return_url": "https://service-name.gov.uk/transactions/12345","language": "en","email": "foo@bar.com","address": {"line1": "address line 1","line2": "address line 2","postcode": "AB1 2CD","city": "address city","country": "GB"}' -H 'Authorization: BEARER_TOKEN' -H 'Content-Type: application/json' http://localhost:8000/v1/payments-7
+$ curl -d '{"amount": 50000,"reference": "12345","description": "New passport application","return_url": "https://service-name.gov.uk/transactions/12345","language": "en","email": "foo@bar.com","billing_address": {"line1": "address line 1","line2": "address line 2","postcode": "AB1 2CD","city": "address city","country": "GB"}' -H 'Authorization: BEARER_TOKEN' -H 'Content-Type: application/json' http://localhost:8000/v1/payments-7
 
 ### Creating a payment - `en` (English language) supplied in language field and delayed capture set to `true`
 
@@ -88,7 +88,3 @@ $ curl -X POST -H 'Authorization: BEARER_TOKEN' -H 'Content-Type: application/js
 ### Initiate capture for a non existing payment
 
 $ curl -X POST -H 'Authorization: BEARER_TOKEN' -H 'Content-Type: application/json' http://localhost:8000/v1/payments-11/789nonexistingpayment123/capture
-
-### Get payment information by card details
-
-$ curl -X POST -H 'Authorization: Bearer BEARER_TOKEN' -H 'Content-Type: application/json'  -d '{"reference":"54321","card_details":{"first_digits_card_number": "123456","last_digits_card_number":"1234","name_on_card":"Mr Card"},"from_date":"2016-01-21T17:15:00Z","to_date":"2016-01-23T17:15:00Z","page":"1","display_size":"100","email":"","state":"success"}' http://localhost:8000/v1/payments-12


### PR DESCRIPTION
Updating the following scenario: ### Create a payment when english language has been specified, as well as an email and postal address supplied 

"address" was the original input but have changed this to be in line with the pact, which is "billing_address"